### PR TITLE
Windows: Fix path handling for tree and file features

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -304,7 +304,23 @@ impl Server {
             path = &path[1..];
         }
         for p in path {
-            path_buf.push(p);
+            if cfg!(windows) {
+                let mut chars = p.chars();
+                match (chars.next(), chars.next(), chars.next()) {
+                    (Some(drive_letter), Some(colon), None)
+                        if drive_letter.is_ascii_alphabetic()
+                            && colon == ':' => {
+                        let mut fixed_drive_prefix = String::new();
+                        fixed_drive_prefix.push(drive_letter);
+                        fixed_drive_prefix.push(colon);
+                        fixed_drive_prefix.push('\\');
+                        path_buf.push(&fixed_drive_prefix);
+                    },
+                    _ => path_buf.push(p),
+                }
+            } else {
+                path_buf.push(p);
+            }
         }
 
         // FIXME should cache directory listings too

--- a/static/app.js
+++ b/static/app.js
@@ -39,7 +39,7 @@ export class RustwApp extends React.Component {
     loadFileTreeData() {
         let self = this;
         utils.request(
-            'tree/' + CONFIG.workspace_root,
+            'tree/' + CONFIG.workspace_root.replace('\\', '/'),
             function(json) {
                 if (json.Directory) {
                     self.setState({ fileTreeData: json })


### PR DESCRIPTION
This PR depends on a build fix, either implemented by https://github.com/nrc/cargo-src/pull/214 or the [`windows-fix-compilation` branch on my fork](https://github.com/ErichDonGubler/cargo-src/tree/windows-fix-compilation). Those changes take different approaches to the problem.

Currently, processing of Windows file paths is totally broken and despite the dependent fixes mention above `cargo-src` will NOT work correctly on a Windows machine right now. This fix essentially:
1. tweaks the front-end to replace file paths appended to the current URL by replacing backslashes with forward slashes
2. adds a check and fix for absolute path segments (drive letters like `C:`) that are missing the slash that is, for some reason, necessary to be used correctly by `PathBuf::push` later. This check/fix combo is ONLY used when compiled for Windows since I'm assuming that `cargo-src` should only ever run locally.

The end result of these changes are that the search and file tree functionalities now work on Windows. Symbol searching is, for some reason, still broken.

ALSO: Travis fails this build, but it seems that CI is breaking on front-end lints only?