### PR TITLE
(174) Begin file_cache refactor - create file_controller sub-module

### DIFF
--- a/src/file_controller/mod.rs
+++ b/src/file_controller/mod.rs
@@ -21,6 +21,16 @@ use super::highlight;
 // FIXME maximum size and evication policy
 // FIXME keep timestamps and check on every read. Then don't empty on build.
 
+mod results;
+use file_controller::results::{
+    SearchResult,
+    DefResult,
+    FileResult,
+    LineResult,
+    FindResult,
+    SymbolResult
+};
+
 pub struct Cache {
     files: Vfs<VfsUserData>,
     analysis: AnalysisHost,
@@ -28,56 +38,6 @@ pub struct Cache {
 }
 
 type Span = span::Span<span::ZeroIndexed>;
-
-#[derive(Serialize, Debug, Clone)]
-pub struct SearchResult {
-    pub defs: Vec<DefResult>,
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct DefResult {
-    pub file: String,
-    pub line: LineResult,
-    pub refs: Vec<FileResult>,
-}
-
-#[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct FileResult {
-    pub file_name: String,
-    pub lines: Vec<LineResult>,
-}
-
-#[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct LineResult {
-    pub line_start: u32,
-    pub column_start: u32,
-    pub column_end: u32,
-    pub line: String,
-}
-
-impl LineResult {
-    fn new(span: &Span, line: String) -> LineResult {
-        LineResult {
-            line_start: span.range.row_start.one_indexed().0,
-            column_start: span.range.col_start.one_indexed().0,
-            column_end: span.range.col_end.one_indexed().0,
-            line: line,
-        }
-    }
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct FindResult {
-    pub results: Vec<FileResult>,
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct SymbolResult {
-    pub id: String,
-    pub name: String,
-    pub file_name: String,
-    pub line_start: u32,
-}
 
 // Our data which we attach to files in the VFS.
 struct VfsUserData {

--- a/src/file_controller/results.rs
+++ b/src/file_controller/results.rs
@@ -1,0 +1,59 @@
+// Copyright 2016 The Rustw Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::Span;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct SearchResult {
+    pub defs: Vec<DefResult>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct DefResult {
+    pub file: String,
+    pub line: LineResult,
+    pub refs: Vec<FileResult>,
+}
+
+#[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct FileResult {
+    pub file_name: String,
+    pub lines: Vec<LineResult>,
+}
+
+#[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct LineResult {
+    pub line_start: u32,
+    pub column_start: u32,
+    pub column_end: u32,
+    pub line: String,
+}
+
+impl LineResult {
+    pub fn new(span: &Span, line: String) -> LineResult {
+        LineResult {
+            line_start: span.range.row_start.one_indexed().0,
+            column_start: span.range.col_start.one_indexed().0,
+            column_end: span.range.col_end.one_indexed().0,
+            line: line,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct FindResult {
+    pub results: Vec<FileResult>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct SymbolResult {
+    pub id: String,
+    pub name: String,
+    pub file_name: String,
+    pub line_start: u32,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use build::BuildArgs;
 
 mod build;
 pub mod config;
-mod file_cache;
+mod file_controller;
 mod listings;
 mod highlight;
 mod server;

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,7 @@
 use analysis;
 use build::{self, BuildArgs};
 use config::Config;
-use file_cache::Cache;
+use file_controller::Cache;
 use listings::{Listing, DirectoryListing};
 use futures;
 use futures::Future;


### PR DESCRIPTION
I'd previously included the addition of a `file_cache.rs` sub-module which separated out the `Cache`, but on review, realized I was duplicating the `Highlighter` object from `highlight.rs`. I was falling down the rabbit hole trying to figure out some lifetimes / ownership issues, so reverted this to a simpler, mechanical splitting out of pre-existing code.